### PR TITLE
Fix dependency installation when using > or >= comparison operator

### DIFF
--- a/addon_system/libraries/pip_manager.py
+++ b/addon_system/libraries/pip_manager.py
@@ -130,9 +130,9 @@ class PipLibManager(BaseLibManager):
 
         if len(libraries):
             out = subprocess.getoutput(
-                str(self._pip_executable.absolute())
+                str(self._pip_executable)
                 + " install "
-                + " ".join(libraries)
+                + " ".join(f'"{lib}"' for lib in libraries)
             )
             if "ERROR" in out:
                 raise RuntimeError(


### PR DESCRIPTION
Dependency installation was broken on linux after adding > and >= comparison operators, because of linux output redirection operator ">"